### PR TITLE
Fix for old browsers without String.trim

### DIFF
--- a/src/CLDRPluralRuleParser.js
+++ b/src/CLDRPluralRuleParser.js
@@ -44,7 +44,7 @@ function pluralRuleParser(rule, number) {
 	*/
 
 	// We don't evaluate the samples section of the rule. Ignore it.
-	rule = rule.split('@')[0].trim();
+	rule = rule.split('@')[0].replace(/^\s*/, '').replace(/\s*$/, '');
 
 	if (!rule.length) {
 		// Empty rule or 'other' rule.


### PR DESCRIPTION
Example: https://bugzilla.wikimedia.org/show_bug.cgi?id=62072 affected
MobileFrontend's "last modified" view on Kindle 3.4 browser

Already submitted in MediaWiki core as https://gerrit.wikimedia.org/r/#/c/116159/
