### PR TITLE
Fix 9: Support both AMD or CommonJS by using UMD returnExports

### DIFF
--- a/src/CLDRPluralRuleParser.js
+++ b/src/CLDRPluralRuleParser.js
@@ -18,6 +18,22 @@
  * @return {boolean} true if evaluation passed, false if evaluation failed.
  */
 
+// UMD returnExports https://github.com/umdjs/umd/blob/master/returnExports.js
+(function(root, factory) {
+	if (typeof define === 'function' && define.amd) {
+		// AMD. Register as an anonymous module.
+		define(factory);
+	} else if (typeof exports === 'object') {
+		// Node. Does not work with strict CommonJS, but
+		// only CommonJS-like environments that support module.exports,
+		// like Node.
+		module.exports = factory();
+	} else {
+		// Browser globals (root is window)
+		root.pluralRuleParser = factory();
+	}
+}(this, function() {
+
 function pluralRuleParser(rule, number) {
 	'use strict';
 
@@ -585,8 +601,6 @@ function pluralRuleParser(rule, number) {
 	return result;
 }
 
-/* For module loaders, e.g. NodeJS, NPM */
-/* global module */
-if (typeof module !== 'undefined' && module.exports) {
-	module.exports = pluralRuleParser;
-}
+return pluralRuleParser;
+
+}));


### PR DESCRIPTION
Use UMD returnExports https://github.com/umdjs/umd/blob/master/returnExports.js in order to support both AMD or CommonJS.
- [x] Does tests pass?
- [ ] Is coding standards correct?
