### PR TITLE
Use the MIT License

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,0 +1,20 @@
+Copyright 2012-2014 Santhosh Thottingal and other contributors
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/package.json
+++ b/package.json
@@ -10,6 +10,12 @@
         "cldrpluralparser": "./src/cli.js"
     },
     "main": "./src/./src/cli.js",
+    "licenses": [
+        {
+            "type": "MIT",
+            "url": "http://opensource.org/licenses/MIT"
+        }
+    ],
     "dependencies": {},
     "devDependencies": {},
     "optionalDependencies": {},

--- a/src/CLDRPluralRuleParser.js
+++ b/src/CLDRPluralRuleParser.js
@@ -2,7 +2,9 @@
  * cldrpluralparser.js
  * A parser engine for CLDR plural rules.
  *
- * Copyright 2012-2013 GPLV3+
+ * Copyright 2012-2014 Santhosh Thottingal and other contributors
+ * Released under the MIT license
+ * http://opensource.org/licenses/MIT
  *
  * @version 0.1.0
  * @source https://github.com/santhoshtr/CLDRPluralRuleParser


### PR DESCRIPTION
As part of our collaboration between jQuery Globalize, Moment.js, cldrjs and Wikipedia, it seems it would make things a lot easier if the CLDRPluralRuleParser project were licensed under MIT.

Contributors that have to sign off to re-license this project under MIT (http://opensource.org/licenses/MIT):
- [x] @santhoshtr (35 commits / 13,344 ++ / 818 --)
- [x] @Krinkle (5 commits / 10,386 ++ / 10,203 --)
- [x] @amire80 (3 commits / 215 ++ / 83 --)
- [ ] @brion (1 commit / 1 ++ / 1 --)
- [x] @rxaviers (1 commit / 19 ++ / 5 --)

There is one user not listed in contributors but listed in git log (@kartikm) who performed a merge.
