### PR TITLE
Specify CLDR data as peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,9 @@
         }
     ],
 	"dependencies": {},
+	"peerDependencies": {
+		"cldr-data": ">=25"
+	},
 	"devDependencies": {},
 	"optionalDependencies": {},
 	"engines": {


### PR DESCRIPTION
Use "cldr-data" npm package to define CLDRPluralRuleParser peer dependency on CLDR data.
