### PR TITLE
Use an SPDX identifier as "license" in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,12 +10,7 @@
 		"cldrpluralruleparser": "./src/cli.js"
 	},
 	"main": "./src/cli.js",
-	"licenses": [
-		{
-			"type": "MIT",
-			"url": "http://opensource.org/licenses/MIT"
-		}
-	],
+	"license": "MIT",
 	"dependencies": {},
 	"peerDependencies": {
 		"cldr-data": ">=25"


### PR DESCRIPTION
As recommended by the NPM documentation:
https://docs.npmjs.com/files/package.json#license